### PR TITLE
Fix build issues on Unity 2021.2

### DIFF
--- a/Assets/MoralisWeb3ApiSdk/WalletConnectSharp.Unity/Network/Client/WebSocket.jslib
+++ b/Assets/MoralisWeb3ApiSdk/WalletConnectSharp.Unity/Network/Client/WebSocket.jslib
@@ -61,7 +61,6 @@ if (typeof TextEncoder === "undefined") {
 }
 
 var LibraryWebSocket = {
-  $textEncoder: new TextEncoder(),
 	$webSocketState: {
 		/*
 		 * Map of instances
@@ -138,7 +137,7 @@ var LibraryWebSocket = {
 	 */
 	WebSocketAllocate: function(url) {
 
-		var urlStr = Pointer_stringify(url);
+		var urlStr = UTF8ToString(url);
 		var id = webSocketState.lastId++;
 
 		webSocketState.instances[id] = {
@@ -159,7 +158,7 @@ var LibraryWebSocket = {
    */
   WebSocketAddSubProtocol: function(instanceId, subprotocol) {
 
-    var subprotocolStr = Pointer_stringify(subprotocol);
+    var subprotocolStr = UTF8ToString(subprotocol);
     webSocketState.instances[instanceId].subprotocols.push(subprotocolStr);
 
   },
@@ -238,7 +237,7 @@ var LibraryWebSocket = {
 				}
 
       } else {
-				var dataBuffer = textEncoder.encode(ev.data);
+				var dataBuffer = (new TextEncoder()).encode(ev.data);
 
 				var buffer = _malloc(dataBuffer.length);
 				HEAPU8.set(dataBuffer, buffer);
@@ -312,7 +311,7 @@ var LibraryWebSocket = {
 		if (instance.ws.readyState === 3)
 			return -5;
 
-		var reason = ( reasonPtr ? Pointer_stringify(reasonPtr) : undefined );
+		var reason = ( reasonPtr ? UTF8ToString(reasonPtr) : undefined );
 
 		try {
 			instance.ws.close(code, reason);
@@ -366,7 +365,7 @@ var LibraryWebSocket = {
 		if (instance.ws.readyState !== 1)
 			return -6;
 
-		instance.ws.send(Pointer_stringify(message));
+		instance.ws.send(UTF8ToString(message));
 
 		return 0;
 
@@ -392,5 +391,4 @@ var LibraryWebSocket = {
 };
 
 autoAddDeps(LibraryWebSocket, '$webSocketState');
-autoAddDeps(LibraryWebSocket, '$textEncoder');
 mergeInto(LibraryManager.library, LibraryWebSocket);


### PR DESCRIPTION
I found the problem and solution for issue #36. In the WalletConnectSharp.unity package they are using the Native WebSockets plugin and this plugin creates the issue. Luckily somebody already created a PR with a fix: https://github.com/endel/NativeWebSocket/pull/54 

So this PR will make the same changes and i can make a WebGL build again on Unity 2021.2.8f1.

