### PR TITLE
Fixed WebGL error: Unsupported internal call for IL2CPP:RuntimeInformation::GetRuntimeArchitecture

### DIFF
--- a/Assets/MoralisWeb3ApiSdk/Moralis/Moralis.WebGL/MoralisDotNet/Platform/EnvironmentData.cs
+++ b/Assets/MoralisWeb3ApiSdk/Moralis/Moralis.WebGL/MoralisDotNet/Platform/EnvironmentData.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Runtime.InteropServices;
 using Moralis.WebGL.Platform.Abstractions;
 
 namespace Moralis.WebGL.Platform
@@ -15,8 +14,8 @@ namespace Moralis.WebGL.Platform
         public static EnvironmentData Inferred => new EnvironmentData
         {
             TimeZone = TimeZoneInfo.Local.StandardName,
-            OSVersion = RuntimeInformation.OSDescription != null ? RuntimeInformation.OSDescription : Environment.OSVersion.ToString(),
-            Platform = RuntimeInformation.FrameworkDescription != null ? RuntimeInformation.FrameworkDescription : ".NET"
+            OSVersion = "unknown", // WebGL doesn't know the OS
+            Platform = ".NET"
         };
 
         /// <summary>


### PR DESCRIPTION
Running the demo on WebGL gives the following error in the browser:

_MetaMask.framework.js:3 NotSupportedException: /Applications/Unity/Hub/Editor/2021.2.12f1/Unity.app/Contents/il2cpp/libil2cpp/icalls/mscorlib/System.Runtime.InteropServices/RuntimeInformation.cpp(34) : Unsupported internal call for IL2CPP:RuntimeInformation::GetRuntimeArchitecture - "This icall is not supported by il2cpp on this architecture."
Rethrow as TypeInitializationException: The type initializer for 'System.Runtime.InteropServices.RuntimeInformation' threw an exception._

RuntimeInformation isn't support so I hardcoded the environment variables for WebGL to fix this
